### PR TITLE
Update Factorio Planner link

### DIFF
--- a/src/app/views/cheat-sheets/science/science.component.html
+++ b/src/app/views/cheat-sheets/science/science.component.html
@@ -86,9 +86,9 @@
         that will produce 90 of each per minute using blue assemblers.
         <br>
         Check your
-        <a href="http://doomeer.com/factorio/index.html#s1132bbbbbbbbbbbbbbrgrgrrrrgrrrrgrgrrrrrrrrrrrrrrrA5rA6rA12rA5rA7rA7rrrrrgrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr" target="_blank">
+        <a href="http://doomeer.com/factorio/#s1132bbbbbbbbbbbbbbrgrgrrrrgrrrrgrgrrrrrrrrrrrrrrrA5rA6rA12rA5rA7rA7rrrrrgrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr" target="_blank">
             Resource requirements
-        </a> to keep production steady
+        </a> to keep production steady.
     </p>
 
     <hr>

--- a/src/app/views/cheat-sheets/science/science.component.html
+++ b/src/app/views/cheat-sheets/science/science.component.html
@@ -86,7 +86,7 @@
         that will produce 90 of each per minute using blue assemblers.
         <br>
         Check your
-        <a href="http://doomeer.com/factorio/#s1132bbbbbbbbbbbbbbrgrgrrrrgrrrgrgrrrrrrrrrrrrrrrA5rA6rA12rA5rA7rA7rrrrgrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr" target="_blank">
+        <a href="http://doomeer.com/factorio/index.html#s1132bbbbbbbbbbbbbbrgrgrrrrgrrrrgrgrrrrrrrrrrrrrrrA5rA6rA12rA5rA7rA7rrrrrgrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr" target="_blank">
             Resource requirements
         </a> to keep production steady
     </p>


### PR DESCRIPTION
Looks like something got added to Factorio Planner that introduced an off-by-one error into the recipe. The link was for maxing out five assembling machines worth of flying robot frames and no yellow science.