### PR TITLE
Fixed whitespace in nuclear-power.component.ts that was causing lint errors

### DIFF
--- a/src/app/views/cheat-sheets/nuclear-power/nuclear-power.component.html
+++ b/src/app/views/cheat-sheets/nuclear-power/nuclear-power.component.html
@@ -166,7 +166,7 @@
                         <th><app-factorio-icon [icon]="dataService.getFactorioIcon('Steam_turbine')"></app-factorio-icon></th>
                         <th><app-factorio-icon [icon]="dataService.getFactorioIcon('Steam', '*Tanks')"></app-factorio-icon></th>
                         <th><i class="fa fa-bolt fa-2x txt-accent" style="vertical-align: middle" aria-hidden="true"></i></th>
-                        <th>Efficiency</th>
+                        <th><app-factorio-icon [icon]="dataService.getFactorioIcon('Efficiency_module_3', 'Efficiency')"></app-factorio-icon></th>
                     </tr>
                 </thead>
                 <tbody>

--- a/src/app/views/cheat-sheets/nuclear-power/nuclear-power.component.html
+++ b/src/app/views/cheat-sheets/nuclear-power/nuclear-power.component.html
@@ -166,6 +166,7 @@
                         <th><app-factorio-icon [icon]="dataService.getFactorioIcon('Steam_turbine')"></app-factorio-icon></th>
                         <th><app-factorio-icon [icon]="dataService.getFactorioIcon('Steam', '*Tanks')"></app-factorio-icon></th>
                         <th><i class="fa fa-bolt fa-2x txt-accent" style="vertical-align: middle" aria-hidden="true"></i></th>
+                        <th>Efficiency</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -177,6 +178,7 @@
                         <td>{{item?.turbines | number:'1.0-1'}}</td>
                         <td>{{item?.steamTanks | number:'1.0-1'}}</td>
                         <td>{{item?.power}} {{item?.powerUnit}}</td>
+                        <td>{{item?.reactorEfficiency}}%</td>
                     </tr>
                 </tbody>
             </table>

--- a/src/app/views/cheat-sheets/nuclear-power/nuclear-power.component.ts
+++ b/src/app/views/cheat-sheets/nuclear-power/nuclear-power.component.ts
@@ -133,7 +133,7 @@ export class NuclearPowerComponent implements OnInit {
         pumps = turbines * (waterPerTurbine / waterPerPump);
         steamTanks = heatExchangers / 4 * storageTanksPerReactor;
 
-        reactorEfficiency = power/(reactors*40);
+        reactorEfficiency = power/(reactors * reactorPower);
         reactorEfficiency = Math.round(reactorEfficiency * 100);
 
         if (power < 1000) {

--- a/src/app/views/cheat-sheets/nuclear-power/nuclear-power.component.ts
+++ b/src/app/views/cheat-sheets/nuclear-power/nuclear-power.component.ts
@@ -133,7 +133,7 @@ export class NuclearPowerComponent implements OnInit {
         pumps = turbines * (waterPerTurbine / waterPerPump);
         steamTanks = heatExchangers / 4 * storageTanksPerReactor;
 
-        reactorEfficiency = power/(reactors * reactorPower);
+        reactorEfficiency = power / (reactors * reactorPower);
         reactorEfficiency = Math.round(reactorEfficiency * 100);
 
         if (power < 1000) {

--- a/src/app/views/cheat-sheets/nuclear-power/nuclear-power.component.ts
+++ b/src/app/views/cheat-sheets/nuclear-power/nuclear-power.component.ts
@@ -117,6 +117,7 @@ export class NuclearPowerComponent implements OnInit {
         let turbines = 1;
         let pumps = 1;
         let steamTanks = 1;
+        let reactorEfficiency = 1;
 
         // Calc data
         if (reactors % 2 === 0) { // Even number of reactors
@@ -131,6 +132,9 @@ export class NuclearPowerComponent implements OnInit {
         turbines = heatExchangers * heatExchangerPower / turbinePower;
         pumps = turbines * (waterPerTurbine / waterPerPump);
         steamTanks = heatExchangers / 4 * storageTanksPerReactor;
+
+        reactorEfficiency = power/(reactors*40);
+        reactorEfficiency = Math.round(reactorEfficiency * 100);
 
         if (power < 1000) {
             powerUnit = 'MW';
@@ -148,7 +152,8 @@ export class NuclearPowerComponent implements OnInit {
             turbines: this.roundUp ? Math.ceil(turbines) : turbines,
             steamTanks: this.roundUp ? Math.ceil(steamTanks) : steamTanks,
             power: power,
-            powerUnit: powerUnit
+            powerUnit: powerUnit,
+            reactorEfficiency: reactorEfficiency
         };
         return data;
 
@@ -165,6 +170,7 @@ interface NukeRatioData {
     steamTanks: number;
     power: number;
     powerUnit: string;
+    reactorEfficiency: number;
 }
 
 interface NuclearData {


### PR DESCRIPTION
Amending pull request 72 (efficiency in nuclear power) https://github.com/DDDGamer/factorio-cheat-sheet/pull/74 to fix whitespace which was causing lint errors.